### PR TITLE
Updated contractNumber type and feedbackMechanism type and generation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -58418,7 +58418,7 @@ const baselineCodeJSON = {
     softwareType: "",
     languages: [],
     maintenance: "",
-    contractNumber: "",
+    contractNumber: [],
     date: {
         created: "",
         lastModified: "",
@@ -58429,7 +58429,7 @@ const baselineCodeJSON = {
         email: "",
         name: "",
     },
-    feedbackMechanisms: [],
+    feedbackMechanisms: "",
     localisation: false,
     repositoryType: "",
     userInput: false,
@@ -58445,10 +58445,7 @@ const baselineCodeJSON = {
 async function getMetaData(existingCodeJSON) {
     const partialCodeJSON = await calculateMetaData();
     // preserve existing feedback mechanisms if they exist, otherwise default to GitHub Issues
-    const existingMechanisms = existingCodeJSON?.feedbackMechanisms || [];
-    const feedbackMechanisms = existingMechanisms.length > 0
-        ? existingMechanisms
-        : [`${partialCodeJSON.repositoryURL}/issues`];
+    const feedbackMechanisms = existingCodeJSON?.feedbackMechanisms || `${partialCodeJSON.repositoryURL}/issues`;
     // only use the calculated description if its not empty, otherwise keep existing
     const shouldUpdateDescription = partialCodeJSON.description && partialCodeJSON.description.trim() !== "";
     const description = shouldUpdateDescription

--- a/dist/model.d.ts
+++ b/dist/model.d.ts
@@ -17,11 +17,11 @@ export interface CodeJSON {
     softwareType: string;
     languages: string[];
     maintenance: string;
-    contractNumber: string;
+    contractNumber: string[];
     date: Date;
     tags: string[];
     contact: Contact;
-    feedbackMechanisms: string[];
+    feedbackMechanisms: string;
     localisation: boolean;
     repositoryType: string;
     userInput: boolean;

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ const baselineCodeJSON: CodeJSON = {
   softwareType: "",
   languages: [],
   maintenance: "",
-  contractNumber: "",
+  contractNumber: [],
   date: {
     created: "",
     lastModified: "",
@@ -43,7 +43,7 @@ const baselineCodeJSON: CodeJSON = {
     email: "",
     name: "",
   },
-  feedbackMechanisms: [],
+  feedbackMechanisms: "",
   localisation: false,
   repositoryType: "",
   userInput: false,
@@ -63,11 +63,10 @@ async function getMetaData(
   const partialCodeJSON = await helpers.calculateMetaData();
 
   // preserve existing feedback mechanisms if they exist, otherwise default to GitHub Issues
-  const existingMechanisms = existingCodeJSON?.feedbackMechanisms || [];
-  const feedbackMechanisms =
-    existingMechanisms.length > 0
-      ? existingMechanisms
-      : [`${partialCodeJSON.repositoryURL}/issues`];
+  const existingMechanisms = existingCodeJSON?.feedbackMechanisms || "";
+  const feedbackMechanisms = existingMechanisms
+    ? existingMechanisms
+    : [`${partialCodeJSON.repositoryURL}/issues`];
 
   // only use the calculated description if its not empty, otherwise keep existing
   const shouldUpdateDescription =

--- a/src/model.ts
+++ b/src/model.ts
@@ -17,11 +17,11 @@ export interface CodeJSON {
   softwareType: string;
   languages: string[]; // calculated
   maintenance: string;
-  contractNumber: string;
+  contractNumber: string[];
   date: Date; // calculated
   tags: string[]; // calculated
   contact: Contact;
-  feedbackMechanisms: string[]; // semi-calculated
+  feedbackMechanisms: string; // calculated
   localisation: boolean;
   repositoryType: string;
   userInput: boolean;


### PR DESCRIPTION
## Problem

Major CMS code.json update that we would like to reflect in this GH Action: https://github.com/DSACMS/gov-codejson/blob/main/schemas/cms/schema-0.2.0.json

## Solution
- `contractNumber` type is now an array
- `feedbackMechanisms` type is now a string
- New field: `AIUseCaseInventory`