### PR TITLE
Add newline to json end-of-file

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -144,7 +144,7 @@ export async function sendPR(
   baseBranchName: string,
 ) {
   try {
-    const formattedContent = JSON.stringify(updatedCodeJSON, null, 2);
+    const formattedContent = JSON.stringify(updatedCodeJSON, null, 2) + "\n";
     const headBranchName = `code-json-${new Date().getTime()}`;
 
     const PR = await octokit.createPullRequest({


### PR DESCRIPTION
While this was partially addressed in `DSACMS/codejson-generator` as part of https://github.com/DSACMS/codejson-generator/pull/43, this change brings the same solution to the _action_, injecting a newline at the end of the json string, ensuring that the resultant `code.json` file adheres to the POSIX definition of a text file.