### PR TITLE
introduced change that fixes issue #91

### DIFF
--- a/src/__tests__/fixtures/mock-deps.ts
+++ b/src/__tests__/fixtures/mock-deps.ts
@@ -41,6 +41,15 @@ export function createMockOctokit(
               parent: null,
             },
           }),
+        getLatestRelease:
+          (overrides.rest?.repos
+            ?.getLatestRelease as OctokitClient["rest"]["repos"]["getLatestRelease"]) ??
+          jest.fn<any>().mockResolvedValue({
+            data: {
+              tag_name: "v1.2.1",
+              name: "v1.2.1",
+            },
+          }),
         listLanguages:
           (overrides.rest?.repos
             ?.listLanguages as OctokitClient["rest"]["repos"]["listLanguages"]) ??

--- a/src/__tests__/unit/helper.test.ts
+++ b/src/__tests__/unit/helper.test.ts
@@ -36,6 +36,7 @@ describe("createHelpers - calculateMetaData", () => {
     const result = await helpers.calculateMetaData();
 
     expect(result.name).toBe("test-repo");
+    expect(result.version).toBe("1.2.1");
     expect(result.description).toBe("A test repository");
     expect(result.repositoryURL).toBe(
       "https://github.com/test-owner/test-repo",
@@ -45,6 +46,24 @@ describe("createHelpers - calculateMetaData", () => {
     expect(result.laborHours).toBeGreaterThan(0);
     expect(result.reuseFrequency?.forks).toBe(5);
     expect(result.tags).toEqual(["test", "automation"]);
+  });
+
+  it("falls back to the existing version when the release lookup fails", async () => {
+    const mockOctokit = createMockOctokit({
+      rest: {
+        repos: {
+          getLatestRelease: jest
+            .fn<any>()
+            .mockRejectedValue(new Error("rate limited")),
+        },
+      },
+    });
+
+    deps = createMockDeps({ octokit: mockOctokit });
+    const helpers = createHelpers(deps);
+    const result = await helpers.calculateMetaData({ version: "9.9.9" } as any);
+
+    expect(result.version).toBe("9.9.9");
   });
 
   it("reports private visibility for private repos", async () => {

--- a/src/__tests__/unit/helper.test.ts
+++ b/src/__tests__/unit/helper.test.ts
@@ -48,7 +48,7 @@ describe("createHelpers - calculateMetaData", () => {
     expect(result.tags).toEqual(["test", "automation"]);
   });
 
-  it("falls back to the existing version when the release lookup fails", async () => {
+  it("returns an empty version when the release lookup fails", async () => {
     const mockOctokit = createMockOctokit({
       rest: {
         repos: {
@@ -61,9 +61,12 @@ describe("createHelpers - calculateMetaData", () => {
 
     deps = createMockDeps({ octokit: mockOctokit });
     const helpers = createHelpers(deps);
-    const result = await helpers.calculateMetaData({ version: "9.9.9" } as any);
+    const result = await helpers.calculateMetaData();
 
-    expect(result.version).toBe("9.9.9");
+    expect(result.version).toBe("");
+    expect(deps.log.warning).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to fetch latest release version"),
+    );
   });
 
   it("reports private visibility for private repos", async () => {

--- a/src/__tests__/unit/main.test.ts
+++ b/src/__tests__/unit/main.test.ts
@@ -109,6 +109,51 @@ describe("getMetaData", () => {
       URL: "https://github.com/upstream-owner/upstream-repo",
     });
   });
+
+  it("uses the latest release version when available", async () => {
+    const releaseOctokit = createMockOctokit({
+      rest: {
+        repos: {
+          getLatestRelease: jest.fn<any>().mockResolvedValue({
+            data: {
+              tag_name: "v2.4.6",
+              name: "Release 2.4.6",
+            },
+          }),
+        },
+      },
+    });
+
+    const deps = createMockDeps({ octokit: releaseOctokit });
+    const helpers = createHelpers(deps);
+
+    const result = await getMetaData(helpers, deps, null);
+
+    expect(result.version).toBe("2.4.6");
+  });
+
+  it("falls back to the existing version when latest release cannot be fetched", async () => {
+    const failingReleaseOctokit = createMockOctokit({
+      rest: {
+        repos: {
+          getLatestRelease: jest
+            .fn<any>()
+            .mockRejectedValue(new Error("network issue")),
+        },
+      },
+    });
+
+    const deps = createMockDeps({ octokit: failingReleaseOctokit });
+    const helpers = createHelpers(deps);
+
+    const result = await getMetaData(
+      helpers,
+      deps,
+      { version: "7.8.9" } as any,
+    );
+
+    expect(result.version).toBe("7.8.9");
+  });
 });
 
 describe("runWithDeps", () => {
@@ -161,6 +206,12 @@ describe("runWithDeps", () => {
           get: jest
             .fn<any>()
             .mockResolvedValue({ data: { default_branch: "main" } }),
+          getLatestRelease: jest.fn<any>().mockResolvedValue({
+            data: {
+              tag_name: "v1.2.1",
+              name: "v1.2.1",
+            },
+          }),
           listLanguages: jest.fn<any>().mockResolvedValue({ data: {} }),
           getContent: jest
             .fn<any>()

--- a/src/__tests__/unit/main.test.ts
+++ b/src/__tests__/unit/main.test.ts
@@ -54,6 +54,29 @@ describe("getMetaData", () => {
     expect(result.feedbackMechanism).toContain("/issues");
   });
 
+  it("preserves an existing version when the latest release is unavailable", async () => {
+    const releaseOctokit = createMockOctokit({
+      rest: {
+        repos: {
+          getLatestRelease: jest
+            .fn<any>()
+            .mockRejectedValue(new Error("not found")),
+        },
+      },
+    });
+
+    const deps = createMockDeps({ octokit: releaseOctokit });
+    const helpers = createHelpers(deps);
+
+    const existing = {
+      ...validCodeJSON,
+      version: "7.8.9",
+    } as any;
+    const result = await getMetaData(helpers, deps, existing);
+
+    expect(result.version).toBe("7.8.9");
+  });
+
   it("sets Archival status when isArchived", async () => {
     const deps = createMockDeps({ isArchived: true });
     const helpers = createHelpers(deps);
@@ -132,28 +155,6 @@ describe("getMetaData", () => {
     expect(result.version).toBe("2.4.6");
   });
 
-  it("falls back to the existing version when latest release cannot be fetched", async () => {
-    const failingReleaseOctokit = createMockOctokit({
-      rest: {
-        repos: {
-          getLatestRelease: jest
-            .fn<any>()
-            .mockRejectedValue(new Error("network issue")),
-        },
-      },
-    });
-
-    const deps = createMockDeps({ octokit: failingReleaseOctokit });
-    const helpers = createHelpers(deps);
-
-    const result = await getMetaData(
-      helpers,
-      deps,
-      { version: "7.8.9" } as any,
-    );
-
-    expect(result.version).toBe("7.8.9");
-  });
 });
 
 describe("runWithDeps", () => {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -13,14 +13,12 @@ export function createHelpers(deps: Dependencies) {
   //===============================================
   // Meta Data
   //===============================================
-  async function calculateMetaData(
-    existingCodeJSON?: CodeJSON | null,
-  ): Promise<Partial<CodeJSON>> {
+  async function calculateMetaData(): Promise<Partial<CodeJSON>> {
     try {
       const [laborHours, basicInfo, version] = await Promise.all([
         getLaborHours(),
         getBasicInfo(),
-        getVersion(existingCodeJSON?.version),
+        getVersion(),
       ]);
 
       return {
@@ -48,7 +46,7 @@ export function createHelpers(deps: Dependencies) {
     }
   }
 
-  async function getVersion(existingVersion?: string): Promise<string> {
+  async function getVersion(): Promise<string> {
     try {
       const release = await octokit.rest.repos.getLatestRelease({ owner, repo });
       const versionFromRelease = normalizeVersionString(release.data.tag_name);
@@ -69,10 +67,6 @@ export function createHelpers(deps: Dependencies) {
       log.warning("Latest release did not include a usable version string.");
     } catch (error) {
       log.warning(`Failed to fetch latest release version: ${error}`);
-    }
-
-    if (typeof existingVersion === "string" && existingVersion.trim() !== "") {
-      return existingVersion.trim();
     }
 
     return "";

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -13,15 +13,19 @@ export function createHelpers(deps: Dependencies) {
   //===============================================
   // Meta Data
   //===============================================
-  async function calculateMetaData(): Promise<Partial<CodeJSON>> {
+  async function calculateMetaData(
+    existingCodeJSON?: CodeJSON | null,
+  ): Promise<Partial<CodeJSON>> {
     try {
-      const [laborHours, basicInfo] = await Promise.all([
+      const [laborHours, basicInfo, version] = await Promise.all([
         getLaborHours(),
         getBasicInfo(),
+        getVersion(existingCodeJSON?.version),
       ]);
 
       return {
         name: basicInfo.title,
+        version: version,
         description: basicInfo.description,
         repositoryURL: basicInfo.url,
         repositoryVisibility: basicInfo.repositoryVisibility,
@@ -42,6 +46,46 @@ export function createHelpers(deps: Dependencies) {
       log.error(`Failed to calculate meta data: ${error}`);
       throw error;
     }
+  }
+
+  async function getVersion(existingVersion?: string): Promise<string> {
+    try {
+      const release = await octokit.rest.repos.getLatestRelease({ owner, repo });
+      const versionFromRelease = normalizeVersionString(release.data.tag_name);
+
+      if (versionFromRelease !== "") {
+        return versionFromRelease;
+      }
+
+      const releaseName = release.data.name;
+      if (typeof releaseName === "string") {
+        const versionFromName = normalizeVersionString(releaseName);
+
+        if (versionFromName !== "") {
+          return versionFromName;
+        }
+      }
+
+      log.warning("Latest release did not include a usable version string.");
+    } catch (error) {
+      log.warning(`Failed to fetch latest release version: ${error}`);
+    }
+
+    if (typeof existingVersion === "string" && existingVersion.trim() !== "") {
+      return existingVersion.trim();
+    }
+
+    return "";
+  }
+
+  function normalizeVersionString(value: string): string {
+    const trimmedValue = value.trim();
+
+    if (trimmedValue.length > 1 && /^v\d/i.test(trimmedValue)) {
+      return trimmedValue.replace(/^v/i, "");
+    }
+
+    return trimmedValue;
   }
 
   async function getBasicInfo(): Promise<BasicRepoInfo> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,7 @@ async function getMetaData(
   deps: Dependencies,
   existingCodeJSON?: CodeJSON | null,
 ): Promise<Partial<CodeJSON>> {
-  const partialCodeJSON = await helpers.calculateMetaData();
+  const partialCodeJSON = await helpers.calculateMetaData(existingCodeJSON);
 
   // preserve existing feedback mechanisms if they exist, otherwise default to GitHub Issues
   const feedbackMechanism =
@@ -150,6 +150,7 @@ async function getMetaData(
 
   return {
     name: partialCodeJSON.name,
+    version: partialCodeJSON.version,
     description: description,
     status: status,
     repositoryURL: partialCodeJSON.repositoryURL,

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,8 @@ async function getMetaData(
   deps: Dependencies,
   existingCodeJSON?: CodeJSON | null,
 ): Promise<Partial<CodeJSON>> {
-  const partialCodeJSON = await helpers.calculateMetaData(existingCodeJSON);
+  const partialCodeJSON = await helpers.calculateMetaData();
+  const version = existingCodeJSON?.version || partialCodeJSON.version;
 
   // preserve existing feedback mechanisms if they exist, otherwise default to GitHub Issues
   const feedbackMechanism =
@@ -150,7 +151,7 @@ async function getMetaData(
 
   return {
     name: partialCodeJSON.name,
-    version: partialCodeJSON.version,
+    version: version,
     description: description,
     status: status,
     repositoryURL: partialCodeJSON.repositoryURL,

--- a/src/types/Dependencies.ts
+++ b/src/types/Dependencies.ts
@@ -32,6 +32,10 @@ export interface OctokitClient {
   rest: {
     repos: {
       get: (params: { owner: string; repo: string }) => Promise<RepoResponse>;
+      getLatestRelease: (params: {
+        owner: string;
+        repo: string;
+      }) => Promise<ReleaseResponse>;
       listLanguages: (params: {
         owner: string;
         repo: string;
@@ -89,6 +93,13 @@ export interface RepoResponse {
 
 export interface LanguagesResponse {
   data: Record<string, number>;
+}
+
+export interface ReleaseResponse {
+  data: {
+    tag_name: string;
+    name: string | null;
+  };
 }
 
 export interface ContentResponse {


### PR DESCRIPTION
## Summary
This PR automates populating the `version` field in `code.json` from the latest GitHub release while preserving the existing merge pattern in `src/main.ts`.

### What changed
- Removed `existingCodeJSON` from `calculateMetaData()` in `src/helper.ts`.
- Kept release lookup logic in the helper, but now it only returns the latest release version string.
- Moved the `version` fallback/merge logic into `src/main.ts`, following the same pattern already used for `feedbackMechanism` and `SBOM`.
- Updated unit tests in:
  - `src/__tests__/unit/helper.test.ts`
  - `src/__tests__/unit/main.test.ts`

### Notes
- The implementation still uses the GitHub API release endpoint because `repos.get()` does not include latest release data.
- If a release version cannot be fetched, `main.ts` preserves the existing `version` from `code.json`.

## Validation
- `npx jest src/__tests__/unit/helper.test.ts src/__tests__/unit/main.test.ts`

### AI Usage
- [x] Generated AI was used in this contribution

If checked, please provide an explanation on how AI was used in the development of this pull request:
- Description: Used ChatGPT (Codex) to refactor the PR to align with the existing project design patterns based on reviewer feedback.
- Type of assistance:  
- [ ] Code generation 
- [ ] Documentation  
- [ ] Debugging  
- [ ] Testing  
- [x] Refactoring  
- [ ] Other:
- Scope of usage: `src/main.ts`, `src/helper.ts`, `src/__tests__/unit/helper.test.ts`, `src/__tests__/unit/main.test.ts`

- AI System used:  
- [x] ChatGPT  
- [ ] Claude  
- [ ] Gemini  
- [ ] GitHub Copilot
- Level of modification:  - [ ] As-is  - [x] Modified  - [ ] Used as inspiration

- Prompts used: "Please refactor my code to address reviewer feedback on my PR... revert the function signature in helper.ts, move the merging logic to main.ts, and update the corresponding unit tests."