### PR TITLE
change that introduces fix to issue 93

### DIFF
--- a/src/__tests__/unit/main.test.ts
+++ b/src/__tests__/unit/main.test.ts
@@ -54,6 +54,28 @@ describe("getMetaData", () => {
     expect(result.feedbackMechanism).toContain("/issues");
   });
 
+  it("preserves existing languages over GitHub-detected languages", async () => {
+    const deps = createMockDeps();
+    const helpers = createHelpers(deps);
+
+    const existing = {
+      ...validCodeJSON,
+      languages: ["TypeScript", "Markdown"],
+    } as any;
+    const result = await getMetaData(helpers, deps, existing);
+
+    expect(result.languages).toEqual(["TypeScript", "Markdown"]);
+  });
+
+  it("falls back to GitHub-detected languages when none exist", async () => {
+    const deps = createMockDeps();
+    const helpers = createHelpers(deps);
+
+    const result = await getMetaData(helpers, deps, null);
+
+    expect(result.languages).toEqual(["TypeScript", "JavaScript"]);
+  });
+
   it("sets Archival status when isArchived", async () => {
     const deps = createMockDeps({ isArchived: true });
     const helpers = createHelpers(deps);

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,6 +112,13 @@ async function getMetaData(
     ? partialCodeJSON.description
     : existingCodeJSON?.description || "";
 
+  // preserve manually curated languages when they already exist in code.json,
+  // and only fall back to GitHub detected languages for new repositories.
+  const languages =
+    existingCodeJSON?.languages && existingCodeJSON.languages.length > 0
+      ? existingCodeJSON.languages
+      : partialCodeJSON.languages;
+
   // only update tags if we have new ones from GitHub Topics, otherwise keep existing
   const shouldUpdateTags =
     partialCodeJSON.tags && partialCodeJSON.tags.length > 0;
@@ -155,7 +162,7 @@ async function getMetaData(
     repositoryURL: partialCodeJSON.repositoryURL,
     repositoryVisibility: partialCodeJSON.repositoryVisibility,
     laborHours: partialCodeJSON.laborHours,
-    languages: partialCodeJSON.languages,
+    languages: languages,
     reuseFrequency: {
       forks: partialCodeJSON.reuseFrequency?.forks ?? 0,
       clones: existingCodeJSON?.reuseFrequency?.clones ?? 0,


### PR DESCRIPTION
## Summary

This PR fixes the metadata generation bug where manually maintained `languages` in `code.json` were being overwritten by GitHub API values during generation.

The behavior now matches the existing tags preservation pattern from issue #92:
- If `languages` already exist in `code.json`, they are preserved.
- If `languages` are missing or empty, the generator falls back to the GitHub-detected languages.
- Added unit coverage for both the preservation path and the fallback path.

## Testing

- `npx jest --runInBand src/__tests__/unit/main.test.ts`

## Related Issue

- Fixes #93