### PR TITLE
change that introduces fix to issue 107

### DIFF
--- a/src/__tests__/unit/main.test.ts
+++ b/src/__tests__/unit/main.test.ts
@@ -152,6 +152,30 @@ describe("runWithDeps", () => {
     expect(deps.setOutput).toHaveBeenCalledWith("method_used", "pull_request");
   });
 
+  it("includes enum keys in the generated blank code.json", async () => {
+    process.env.GITHUB_EVENT_NAME = "schedule";
+
+    const deps = createMockDeps({
+      readFile: jest.fn<any>().mockRejectedValue(new Error("no file")),
+      skipPR: false,
+    });
+
+    await runWithDeps(deps);
+
+    const createPullRequestMock = deps.octokit.createPullRequest as jest.Mock;
+    const pullRequestArgs = createPullRequestMock.mock.calls[0][0] as any;
+    const codeJSONContent = pullRequestArgs.changes[0].files["code.json"];
+    const generatedCodeJSON = JSON.parse(codeJSONContent);
+
+    expect(generatedCodeJSON).toHaveProperty("status");
+    expect(generatedCodeJSON).toHaveProperty("repositoryHost");
+    expect(generatedCodeJSON).toHaveProperty("repositoryVisibility");
+    expect(generatedCodeJSON).toHaveProperty("softwareType");
+    expect(generatedCodeJSON).toHaveProperty("maintenance");
+    expect(generatedCodeJSON).toHaveProperty("repositoryType");
+    expect(generatedCodeJSON).toHaveProperty("fismaLevel");
+  });
+
   it("attempts direct push when skipPR is true with admin token", async () => {
     process.env.GITHUB_EVENT_NAME = "workflow_dispatch";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,12 +3,14 @@ import { Dependencies } from "./types/Dependencies.js";
 import { createHelpers, Helpers } from "./helper.js";
 import { createProductionDeps } from "./create-deps.js";
 
+const blankEnumValue = "" as never;
+
 const baselineCodeJSON: Partial<CodeJSON> = {
   name: "",
   version: "",
   description: "",
   longDescription: "",
-  status: undefined,
+  status: blankEnumValue,
   permissions: {
     licenses: [
       {
@@ -21,8 +23,8 @@ const baselineCodeJSON: Partial<CodeJSON> = {
   },
   organization: "Centers for Medicare & Medicaid Services",
   repositoryURL: "",
-  repositoryHost: undefined,
-  repositoryVisibility: undefined,
+  repositoryHost: blankEnumValue,
+  repositoryVisibility: blankEnumValue,
   homepageURL: "",
   downloadURL: "",
   disclaimerURL: "",
@@ -35,9 +37,9 @@ const baselineCodeJSON: Partial<CodeJSON> = {
   },
   platforms: [],
   categories: [],
-  softwareType: undefined,
+  softwareType: blankEnumValue,
   languages: [],
-  maintenance: undefined,
+  maintenance: blankEnumValue,
   contractNumber: [],
   SBOM: "",
   relatedCode: [],
@@ -56,9 +58,9 @@ const baselineCodeJSON: Partial<CodeJSON> = {
   feedbackMechanism: "",
   AIUseCaseID: "0",
   localisation: false,
-  repositoryType: undefined,
+  repositoryType: blankEnumValue,
   userInput: false,
-  fismaLevel: undefined,
+  fismaLevel: blankEnumValue,
   group: "",
   projects: [],
   systems: [],
@@ -151,7 +153,7 @@ async function getMetaData(
   return {
     name: partialCodeJSON.name,
     description: description,
-    status: status,
+    status: status ?? blankEnumValue,
     repositoryURL: partialCodeJSON.repositoryURL,
     repositoryVisibility: partialCodeJSON.repositoryVisibility,
     laborHours: partialCodeJSON.laborHours,


### PR DESCRIPTION
## Summary

Fix enum fields disappearing from generated blank `code.json` templates.

This addresses [Issue #107](https://github.com/DSACMS/automated-codejson-generator/issues/107), where enum-backed fields were being omitted from the blank `code.json` even though they are part of the CMS schema. The generator now preserves blank placeholder values for those enum fields instead of letting them get dropped during JSON serialization or overwritten as `undefined` during metadata merging.

The generated `code.json` now includes the full schema shape, including:

- `status`
- `repositoryHost`
- `repositoryVisibility`
- `softwareType`
- `maintenance`
- `repositoryType`
- `fismaLevel`

A regression test was added to verify the generated PR payload still contains those enum keys in the blank template.

## Testing

- `npx jest --runInBand src/__tests__/unit/main.test.ts`
- `npx jest --runInBand`