### PR TITLE
Change that fixes issue 92

### DIFF
--- a/src/__tests__/unit/main.test.ts
+++ b/src/__tests__/unit/main.test.ts
@@ -121,9 +121,7 @@ describe("getMetaData", () => {
 
     const result = await getMetaData(helpers, deps, existing);
 
-    expect(result.tags).toEqual(
-      expect.arrayContaining(["test", "automation", "featured"]),
-    );
+    expect(result.tags).toEqual(["test", "automation", "featured"]);
   });
 
   it("does not duplicate tags that already exist as repository topics", async () => {

--- a/src/__tests__/unit/main.test.ts
+++ b/src/__tests__/unit/main.test.ts
@@ -109,6 +109,45 @@ describe("getMetaData", () => {
       URL: "https://github.com/upstream-owner/upstream-repo",
     });
   });
+
+  it("preserves existing tags that are not repository topics", async () => {
+    const deps = createMockDeps();
+    const helpers = createHelpers(deps);
+
+    const existing = {
+      ...validCodeJSON,
+      tags: ["featured"],
+    } as any;
+
+    const result = await getMetaData(helpers, deps, existing);
+
+    expect(result.tags).toEqual(
+      expect.arrayContaining(["test", "automation", "featured"]),
+    );
+  });
+
+  it("does not duplicate tags that already exist as repository topics", async () => {
+    const deps = createMockDeps();
+    const helpers = createHelpers(deps);
+
+    const existing = {
+      ...validCodeJSON,
+      tags: ["test", "featured"],
+    } as any;
+
+    const result = await getMetaData(helpers, deps, existing);
+
+    expect(result.tags).toEqual(["test", "automation", "featured"]);
+  });
+
+  it("uses repository topics when no existing code.json is present", async () => {
+    const deps = createMockDeps();
+    const helpers = createHelpers(deps);
+
+    const result = await getMetaData(helpers, deps, null);
+
+    expect(result.tags).toEqual(["test", "automation"]);
+  });
 });
 
 describe("runWithDeps", () => {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -334,6 +334,7 @@ export function createHelpers(deps: Dependencies) {
     readJSON,
     sendPR,
     pushDirectlyWithFallback,
+    mergeTags,
   };
 }
 
@@ -388,6 +389,14 @@ export function mergeReusedCode(
   }
 
   return merged;
+}
+
+// combines repository topics with existing manually added tags, de-duped
+export function mergeTags(
+  repositoryTopics: string[] = [],
+  existingTags: string[] = [],
+): string[] {
+  return Array.from(new Set([...repositoryTopics, ...existingTags]));
 }
 
 function bodyOfPR(): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,12 +112,11 @@ async function getMetaData(
     ? partialCodeJSON.description
     : existingCodeJSON?.description || "";
 
-  // only update tags if we have new ones from GitHub Topics, otherwise keep existing
-  const shouldUpdateTags =
-    partialCodeJSON.tags && partialCodeJSON.tags.length > 0;
-  const tags = shouldUpdateTags
-    ? partialCodeJSON.tags
-    : existingCodeJSON?.tags || [];
+  // preserve existing tags and append repository topics, de-duped
+  const tags = helpers.mergeTags(
+    partialCodeJSON.tags ?? [],
+    existingCodeJSON?.tags ?? [],
+  );
 
   // handling legacy contractNumber that turned from string to array which caused validation errors
   let contractNumber: string[] = [];
@@ -135,7 +134,7 @@ async function getMetaData(
 
   if (deps.isArchived) {
     status = "Archival";
-    tags?.push("archived");
+    tags.push("archived");
   }
 
   // detect the fork upstream and government-made dependencies, then merge with any existing reusedCode


### PR DESCRIPTION
# Problem

Repository tags generated from GitHub topics were overwriting the existing `tags` field in `code.json`.

This caused any tags that had been manually added to `code.json` (but did not exist as GitHub repository topics) to be removed the next time the metadata generator ran. As a result, custom tags such as `featured` would be lost in future generated PRs.

# Solution

Added a `mergeTags` helper that combines the detected GitHub repository topics with the existing `code.json` tags while removing duplicates.

Instead of replacing the existing tags when repository topics are present, the metadata generator now merges both sources, preserving manually added tags while still including the repository topics.

# Tests

Added unit tests covering the new merge behavior:

- **Preserves existing tags that are not repository topics**
  - Verifies that tags present only in `code.json` are retained after metadata generation.

- **Does not duplicate tags that already exist as repository topics**
  - Verifies that tags appearing in both GitHub repository topics and `code.json` are included only once.

- **Uses repository topics when no existing `code.json` is present**
  - Verifies that repositories without an existing `code.json` continue to use the detected GitHub repository topics as before.
  
  **Closes** #92 